### PR TITLE
[Git] Config: Remove format-escapes

### DIFF
--- a/Git Files/Git Config.sublime-syntax
+++ b/Git Files/Git Config.sublime-syntax
@@ -155,8 +155,6 @@ contexts:
 
   # The only valid escapes: '\b', '\n', '\t', '\"', '\\'.
   escape:
-    - match: '%[A-Za-z]'
-      scope: constant.character.escape.git.config
     - match: \\[{{escape_char}}]
       scope: constant.character.escape.git.config
     - match: \\[^{{escape_char}}]


### PR DESCRIPTION
The format-escapes are not feature complete and
don't cover all git --format arguments. Therefore
they are removed for now.

The question whether highlighting values is valuable
may be answered later.